### PR TITLE
fix: userId type number type에서 string으로 교체

### DIFF
--- a/src/api/datingHome.ts
+++ b/src/api/datingHome.ts
@@ -2,7 +2,7 @@ import { apiClient } from "./client";
 
 export type DatingHomeCard = {
   id: string;
-  userId: number;
+  userId: string;
   profile: string;
 };
 
@@ -45,13 +45,13 @@ const isProfileCard = (value: unknown): value is DatingHomeCard => {
   const profile = value as Record<string, unknown>;
 
   return (
-    typeof profile.userId === "number" &&
+    typeof profile.userId === "string" &&
     typeof profile.profile === "string"
   );
 };
 
 const normalizeProfileCard = (profile: DatingHomeCard): DatingHomeCard => ({
-  id: String(profile.userId),
+  id: profile.userId,
   userId: profile.userId,
   profile: profile.profile,
 });

--- a/src/api/datingProfile.ts
+++ b/src/api/datingProfile.ts
@@ -13,7 +13,7 @@ type CreateDatingProfileRequest = {
 };
 
 export type CreateDatingProfileResponse = {
-  userId: number;
+  userId: string;
   status: {
     isRegistered: boolean;
     hasIntroduction: boolean;
@@ -33,7 +33,7 @@ const isCreateDatingProfileResponse = (
   const status = response.status as Record<string, unknown> | undefined;
 
   return (
-    typeof response.userId === "number" &&
+    typeof response.userId === "string" &&
     !!status &&
     typeof status.isRegistered === "boolean" &&
     typeof status.hasIntroduction === "boolean" &&

--- a/src/components/AlarmModal.stories.tsx
+++ b/src/components/AlarmModal.stories.tsx
@@ -21,7 +21,7 @@ export const Like: Story = {
   args: {
     notification: {
       notificationId: 1,
-      userId: 1,
+      userId: "1",
       type: "LIKE",
       title: "새로운 호감이 도착했어요",
       content: "누군가 나에게 호감을 보냈어요!",
@@ -35,7 +35,7 @@ export const Match: Story = {
   args: {
     notification: {
       notificationId: 2,
-      userId: 1,
+      userId: "1",
       type: "MATCH",
       title: "쌍방 매칭이 됐어요",
       content: "쌍방 매칭이 이뤄졌어요!",
@@ -49,7 +49,7 @@ export const Cookie: Story = {
   args: {
     notification: {
       notificationId: 3,
-      userId: 1,
+      userId: "1",
       type: "COOKIE",
       title: "쿠키 지급",
       content: "친구가 추천인 코드로 가입했어요! 쿠키 20개 지급 완료",

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -17,7 +17,7 @@ import arrowIcon from '../../assets/arrowIcon.svg';
 // TODO: API 연동 시 GET /api/users/me 응답으로 교체
 const mockResponse = {
   user: {
-    userId: 123,
+    userId: '123',
     nickname: '콩순이짱',
     birthYear: 2003,
     gender: '여',

--- a/src/pages/NotificationPage/NotificationPage.tsx
+++ b/src/pages/NotificationPage/NotificationPage.tsx
@@ -6,7 +6,7 @@ import type { Notification, NotificationType } from "../../types/notification";
 const MOCK_NOTIFICATIONS: Notification[] = [
   {
     notificationId: 1,
-    userId: 1,
+    userId: "1",
     type: "LIKE",
     title: "새로운 호감이 도착했어요",
     content: "개구쟁이님이 나에게 호감을 보냈어요!",
@@ -15,7 +15,7 @@ const MOCK_NOTIFICATIONS: Notification[] = [
   },
   {
     notificationId: 2,
-    userId: 1,
+    userId: "1",
     type: "MATCH",
     title: "쌍방 매칭이 됐어요",
     content: "코개구리님과 쌍방 매칭 됐어요",
@@ -24,7 +24,7 @@ const MOCK_NOTIFICATIONS: Notification[] = [
   },
   {
     notificationId: 3,
-    userId: 1,
+    userId: "1",
     type: "COOKIE",
     title: "쿠키 지급",
     content: "친구가 추천인 코드로 가입했어요! 쿠키 10개 지급 완료",
@@ -33,7 +33,7 @@ const MOCK_NOTIFICATIONS: Notification[] = [
   },
   {
     notificationId: 4,
-    userId: 1,
+    userId: "1",
     type: "EVENT",
     title: "이벤트 쿠키 지급",
     content: "축제 이벤트 쿠키 1개 지급 완료",
@@ -42,7 +42,7 @@ const MOCK_NOTIFICATIONS: Notification[] = [
   },
   {
     notificationId: 5,
-    userId: 1,
+    userId: "1",
     type: "LIKE",
     title: "새로운 호감이 도착했어요",
     content: "레모나셔님이 나에게 호감을 보냈어요!",
@@ -51,7 +51,7 @@ const MOCK_NOTIFICATIONS: Notification[] = [
   },
   {
     notificationId: 6,
-    userId: 1,
+    userId: "1",
     type: "INTRODUCTION",
     title: "소개서가 도착했어요",
     content: "금보리차님의 소개서가 도착했어요!",
@@ -60,7 +60,7 @@ const MOCK_NOTIFICATIONS: Notification[] = [
   },
   {
     notificationId: 7,
-    userId: 1,
+    userId: "1",
     type: "REFERRAL",
     title: "가입 보상",
     content: "가입 보상으로 쿠키 3개 지급해드려요",

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -8,7 +8,7 @@ export type NotificationType =
 
 export type Notification = {
   notificationId: number;
-  userId: number;
+  userId: string;
   type: NotificationType;
   title: string;
   content: string;


### PR DESCRIPTION
## 작업 내용
- request / response로 전달받는 userId type string으로 지정

## 관련 이슈
Closes #76
