### PR TITLE
hotfix: 고객센터 링크 변경

### DIFF
--- a/src/constants/customerSupport.ts
+++ b/src/constants/customerSupport.ts
@@ -1,1 +1,1 @@
-export const CUSTOMER_SUPPORT_KAKAO_URL = 'https://open.kakao.com/o/sHQFocui';
+export const CUSTOMER_SUPPORT_KAKAO_URL = 'https://open.kakao.com/o/siaFfevi';

--- a/src/pages/MyPage/CanceledModal.tsx
+++ b/src/pages/MyPage/CanceledModal.tsx
@@ -1,6 +1,5 @@
 import XIcon from '../../assets/X.svg';
-
-const INQUIRY_URL = 'https://open.kakao.com/o/sHQFocui';
+import { CUSTOMER_SUPPORT_KAKAO_URL } from '../../constants/customerSupport';
 
 type CanceledModalProps = {
   onClose: () => void;
@@ -25,7 +24,7 @@ function CanceledModal({ onClose }: CanceledModalProps) {
           문의해주세요
         </p>
         <a
-          href={INQUIRY_URL}
+          href={CUSTOMER_SUPPORT_KAKAO_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="flex h-[3.125rem] w-[18.75rem] items-center justify-center rounded-[0.875rem] bg-[#fff5c4] typo-button-text-b text-[#ff8250]"

--- a/src/pages/MyPage/CookieFailureModal.tsx
+++ b/src/pages/MyPage/CookieFailureModal.tsx
@@ -1,7 +1,6 @@
 import ArrowIcon from "../../assets/arrowIcon.svg?react";
 import XIcon from "../../assets/X.svg";
-
-const INQUIRY_URL = "https://open.kakao.com/o/sHQFocui";
+import { CUSTOMER_SUPPORT_KAKAO_URL } from '../../constants/customerSupport';
 
 type CookieFailureModalProps = {
   onBack: () => void;
@@ -35,7 +34,7 @@ function CookieFailureModal({ onBack, onClose }: CookieFailureModalProps) {
         </div>
         <div className="flex flex-col gap-2.5">
           <a
-            href={INQUIRY_URL}
+            href={CUSTOMER_SUPPORT_KAKAO_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="flex h-[3.125rem] w-[18.75rem] items-center justify-center rounded-[0.875rem] bg-[#fff5c4] text-[#ff8250] typo-button-text-b"


### PR DESCRIPTION
## 작업 내용
- 고객센터 링크 변경
- 사용처 네 곳 모두 상수(CUSTOMER_SUPPORT_KAKAO_URL) 쓰도록 리팩토링

## 관련 이슈
Closes #228 
